### PR TITLE
Patches json6902 to patches and more instruction changes

### DIFF
--- a/documentation/modules/ROOT/examples/bgd-base/kustomization.yaml
+++ b/documentation/modules/ROOT/examples/bgd-base/kustomization.yaml
@@ -1,3 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - bgd-deployment.yaml
 - bgd-route.yaml

--- a/documentation/modules/ROOT/examples/bgdk/kustomization.yaml
+++ b/documentation/modules/ROOT/examples/bgdk/kustomization.yaml
@@ -2,13 +2,13 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../bgd-base
-patchesJson6902:
-  - target:
-      version: v1
-      group: apps
-      kind: Deployment
-      name: bgd
-    patch: |-
-      - op: replace
-        path: /spec/template/spec/containers/0/env/0/value
-        value: yellow
+patches:
+- patch: |-
+    - op: replace
+      path: /spec/template/spec/containers/0/env/0/value
+      value: yellow
+  target:
+    group: apps
+    kind: Deployment
+    name: bgd
+    version: v1

--- a/documentation/modules/ROOT/examples/kustomize-build/kustomization.yaml
+++ b/documentation/modules/ROOT/examples/kustomize-build/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ./welcome.yaml
-patchesJson6902:
+patches:
 - patch: |-
     - op: add
       path: /metadata/labels/testkey
@@ -12,6 +12,3 @@ patchesJson6902:
     kind: Deployment
     name: welcome-php
     version: v1
-images:
-- name: quay.io/redhatworkshops/welcome-php
-  newTag: ffcd15

--- a/documentation/modules/ROOT/pages/02-gitops-basics.adoc
+++ b/documentation/modules/ROOT/pages/02-gitops-basics.adoc
@@ -95,7 +95,7 @@ DevSpaces] is a better choice.
 
 === Review the Application Manifests
 
-For our first lab, the application manifests include a link:[bgdk-app.yaml,window='_blank']Deployment, Service, and Route.
+For this first lab, the application manifests are located link:https://github.com/OpenShiftDemos/openshift-gitops-workshop/blob/master/documentation/modules/ROOT/examples/bgd[here,window='_blank'] and include a Deployment, Service, and Route.
 
 [IMPORTANT]
 ====
@@ -103,7 +103,7 @@ Review, but do not apply these manifests to your cluster. You will do that
 shortly using Argo CD.
 ====
 
-*Deployment*:
+A *Deployment*:
 
 [source,yaml,subs="+macros,attributes+"]
 ----
@@ -132,9 +132,10 @@ link:https://argo-cd.readthedocs.io/en/stable/operator-manual/declarative-setup/
 CR (CustomResource)^] in order to have Argo CD apply these manifests in your
 cluster.
 
-Let's review the Argo CD Application manifest used to deploy this application
+Let's review the `Application` manifest used to deploy this application (found link:https://github.com/OpenShiftDemos/openshift-gitops-workshop/blob/master/documentation/modules/ROOT/examples/bgd-app.yaml[here,window="_blank"])
 and break this down a bit:
 
+.link:https://github.com/OpenShiftDemos/openshift-gitops-workshop/blob/master/documentation/modules/ROOT/examples/bgd-app.yaml[bgd-app.yaml,window="_blank"]
 [source,yaml,subs="+macros,attributes+"]
 ----
 apiVersion: argoproj.io/v1alpha1
@@ -143,13 +144,13 @@ metadata:
   name: bgd-app
 spec:
   destination:
-    namespace: bgd
+    namespace: user$USERNUM-bgd
     server: https://kubernetes.default.svc <1>
   project: default <2>
   source: <3>
     path: documentation/modules/ROOT/examples/bgd
     repoURL: https://github.com/OpenShiftDemos/openshift-gitops-workshop
-    targetRevision: main
+    targetRevision: master
   syncPolicy: <4>
     automated:
       prune: true
@@ -224,7 +225,7 @@ route.route.openshift.io/bgd   bgd-user3-bgd.apps.cluster-7pjzx.7pjzx.sandbox141
 
 **Extra Credit:** Do you know why you have a ReplicaSet?
 
-Verify the the rollout is complete:
+Wait for the rollout of the new pods to happen in the deployment:
 
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
@@ -263,6 +264,7 @@ blue to green:
 
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
+
 ----
 kubectl -n user%USERNUM%-bgd patch deploy/bgd --type='json' -p='[{"op": "replace", "path": "/spec/template/spec/containers/0/env/0/value", "value":"green"}]'
 ----
@@ -301,16 +303,18 @@ have returned to their original blue color.
 image::bgd.png[BDG App]
 
 You can set up Argo CD to automatically correct drift by setting the `selfHeal`
-property of the `Application` manifest to do so. Example:
+property of the `Application` manifest to do so. Using the example from link:#_deploy_the_application[above]:
 
 [.console-input]
 [source,yaml,subs="attributes+,+macros"]
 ----
+# bgd-app.yaml
+...
 spec:
   syncPolicy:
     automated:
       prune: true
-      selfHeal: true
+      selfHeal: true # Set this to true
 ----
 
 Or, as in our case, after the fact by running the following command:
@@ -320,5 +324,3 @@ Or, as in our case, after the fact by running the following command:
 ----
 oc patch application/bgd-app -n user%USERNUM%-argocd --type=merge -p='{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
 ----
-
-To see an example of an `Application` manifest in Git, check out link:https://github.com/OpenShiftDemos/openshift-gitops-workshop/blob/master/documentation/modules/ROOT/examples/bgd-app.yaml[bgd-app.yaml,window='_blank']

--- a/documentation/modules/ROOT/pages/03-kustomize.adoc
+++ b/documentation/modules/ROOT/pages/03-kustomize.adoc
@@ -43,12 +43,14 @@ This should display the version, it should look something like this.
 
 
 Kustomize, at its core, is meant to build on top of native Kubernetes manifests
-based on YAML while leaving the original YAML in tact. It achieves this in a
+based on YAML while leaving the original YAML intact. It achieves this in a
 "template-less" templating format. This is done by providing a
 `kustomization.yaml` file.
 
 We will be focusing on two Kustomize sub-commands: the `build` command and the
 `edit` command.
+
+### Kustomize `build`
 
 The `build` command takes the YAML source (via a path or URL) and creates a new
 YAML that can be piped into `oc create`. We will work with an example in the
@@ -61,8 +63,7 @@ repository you cloned.
 cd ~/openshift-gitops-workshop/documentation/modules/ROOT/examples/kustomize-build
 ----
 
-Here you should see two files, a `kustomization.yaml` file and a `welcome.yaml`
-file, let's have a look at them.
+Here you should see two files, a `welcome.yaml` file and a `kustomization.yaml` file, let's have a look at them.
 
 .link:https://github.com/OpenShiftDemos/openshift-gitops-workshop/blob/master/documentation/modules/ROOT/examples/kustomize-build/welcome.yaml[welcome.yaml,window='_blank']
 [source,yaml,subs="+macros,attributes+"]
@@ -70,9 +71,9 @@ file, let's have a look at them.
 include::ROOT:example$kustomize-build/welcome.yaml[]
 ----
 
-This file shows nothing special. Just a standard Kubernetes manifest.
+This file shows nothing special. Just a standard Kubernetes `Deployment` manifest.
 
-What if, for example, we wanted to add a `label` to this manifest without
+Now what if, for example, we wanted to add a `label` to this manifest without
 editing it? This is where the `kustomization.yaml` file comes in.
 
 .link:https://github.com/OpenShiftDemos/openshift-gitops-workshop/blob/master/documentation/modules/ROOT/examples/kustomize-build/kustomization.yaml[kustomization.yaml,window='_blank']
@@ -81,20 +82,17 @@ editing it? This is where the `kustomization.yaml` file comes in.
 include::ROOT:example$kustomize-build/kustomization.yaml[]
 ----
 
-As you can see in the output there isn't much. The two sections for this
-example are the `resources` and the `patchesJson6902` sections.
+As you can see in the output, we only need a `resources` and a `patches` section to accomplish this:
 
-`resources` is an array of individual files, directories, and/or URLs where
-other manifests are stored. In this example we are just loading in one file. The
-(https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patchesjson6902/[`patchesJson6902`
-is a patching RFC] that `kustomize` supports. As you can see, in the
-`patchesJson6902` file, I am adding a label to this manifest.
+- The `resources` is an array of individual files, directories, and/or URLs where
+other manifests are stored. In this example we are just loading in one file.
+- The link:https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/patches/[`patches`,window="blank"] is where we add our label to this manifest.
 
 [NOTE]
 ====
 You can read about what options are available for patching in the
 https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/[official
-documentation site]
+documentation site,window="blank"]
 ====
 
 Build this manifest by running:
@@ -113,10 +111,9 @@ You can see that the new label got added to the manifest!
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  creationTimestamp: null
   labels:
     app: welcome-php
-    testkey: testvalue
+    testkey: testvalue # Our new label
   name: welcome-php
 spec:
   replicas: 1
@@ -126,18 +123,19 @@ spec:
   strategy: {}
   template:
     metadata:
-      creationTimestamp: null
       labels:
         app: welcome-php
     spec:
       containers:
-      - image: quay.io/redhatworkshops/welcome-php:ffcd15
+      - image: quay.io/redhatworkshops/welcome-php:latest
         name: welcome-php
         resources: {}
 ----
 
-You can use the `kustomize edit` command instead of writing YAML. For
-example, you can change the image tag this `Deployment` uses from `latest`
+### Kustomize `edit`
+
+You can use the `kustomize edit` command to make manifest changes instead of manually writing YAML. For
+example, you can change the image tag the `Deployment` above uses from `latest`
 to `ffcd15` by running the following:
 
 [.console-input]
@@ -146,7 +144,7 @@ to `ffcd15` by running the following:
 kustomize edit set image quay.io/redhatworkshops/welcome-php:ffcd15
 ----
 
-This will update the `kustomization.yaml` file with a `images` section.
+This will update the `kustomization.yaml` file with an `images` section.
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
@@ -160,7 +158,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ./welcome.yaml
-patchesJson6902:
+patches:
 - patch: |-
     - op: add
       path: /metadata/labels/testkey


### PR DESCRIPTION
Updated the patchesJson6902 to patches and, having another pass at this, tweaked a few more instructions based on flow. I also adjusted the kustomization.yaml in kustomize-build to remove the image since I don't think it was supposed to be there. Instructions cleared up a lot for me with that change. @gnunn1, thanks for reviewing this!