### PR TITLE
Correct filename case from 'chart.yaml' to 'Chart.yaml'

### DIFF
--- a/content/modules/ROOT/pages/04-helm.adoc
+++ b/content/modules/ROOT/pages/04-helm.adoc
@@ -71,7 +71,7 @@ as a directory called templates. Let's have a look at these in more detail.
 [.console-input]
 [source,bash,subs="attributes+,+macros"]
 ----
-cat ./chart.yaml
+cat ./Chart.yaml
 ----
 
 .link:https://github.com/OpenShiftDemos/openshift-gitops-workshop/blob/{gitops_revision}/content/modules/ROOT/examples/bgd-helm-chart/Chart.yaml[Chart.yaml,window='_blank']


### PR DESCRIPTION
The filename in the repository is "Chart.yaml" at openshift-gitops-workshop/content/modules/ROOT/pages/04-helm.adoc